### PR TITLE
refactor: position homepage around reliability systems and flagships

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     template: `%s | ${profile.name}`,
   },
   description:
-    'Portfolio of Vincent Mogah: Azure infrastructure, DevOps and GitOps, identity reliability (Entra ID / Microsoft 365), and observability.',
+    'Portfolio of Vincent Mogah: AI-native reliability systems, operator diagnostics tooling, and production platform engineering.',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,10 +19,21 @@ export default function HomePage() {
   const currentRole = experience[0];
   const githubHref = safeExternalHref(profile.links.github);
   const linkedinHref = safeExternalHref(profile.links.linkedin);
+  const profileLeads = [
+    'I build AI-native reliability systems that turn recurring pain into reusable tooling.',
+    'Evidence, deterministic defaults, and escalation boundaries gate all automation.',
+    'The result is product-style reliability work grounded in real cloud and CI/CD operations.',
+  ];
   type CertificationWithHref = (typeof featuredCerts)[number] & { href: string };
   const featuredCertsSafe: CertificationWithHref[] = featuredCerts
     .map(c => ({ ...c, href: safeExternalHref(c.link) }))
     .filter((c): c is CertificationWithHref => Boolean(c.href));
+  const heroHighlights = [
+    'Evidence-first diagnostics',
+    'Policy-aware remediation',
+    'Bounded AI explanation',
+    'Reusable platform tooling',
+  ];
   const homeJumpLinks = [
     { href: '/#projects', label: 'Selected work' },
     { href: '/#experience', label: 'Experience' },
@@ -30,9 +41,9 @@ export default function HomePage() {
     { href: '/#writing', label: 'Writing' },
   ];
   const workPrinciples = [
-    'Automate, observe, then simplify.',
+    'Automate once evidence is deterministic.',
     'Boring runbooks beat clever recovery.',
-    'Write it down and make it reproducible.',
+    'If it is not repeatable, it is not done.',
   ];
 
   return (
@@ -41,15 +52,13 @@ export default function HomePage() {
         <div className="grid gap-10 md:grid-cols-2 md:items-stretch">
           <div>
             <p className="text-sm font-medium tracking-wide text-[color:var(--color-text-secondary)]">
-              {profile.headline}
+              AI-native reliability builder
             </p>
             <h1 className="mt-4 text-5xl font-semibold tracking-tight md:text-6xl">
-              {profile.name}
+              {profile.name} builds reusable reliability systems
             </h1>
             <p className="mt-5 max-w-xl text-[color:var(--color-text-secondary)] leading-7">
-              I design and operate production systems: GitOps-driven Kubernetes, identity
-              reliability, and observability. Measured in safe deploys, clean dashboards, and boring
-              on-call.
+              I turn recurring failures into reusable diagnostics and operator tooling.
             </p>
 
             <div className="mt-7 flex flex-wrap gap-3">
@@ -65,10 +74,11 @@ export default function HomePage() {
             </div>
 
             <div className="mt-7 flex flex-wrap gap-2">
-              <Badge variant="tech">2 clusters: OKE hub + AKS spoke</Badge>
-              <Badge variant="tech">GitOps: Argo CD</Badge>
-              <Badge variant="tech">CI: Jenkins multibranch</Badge>
-              <Badge variant="tech">Telemetry: OTLP → LGTM</Badge>
+              {heroHighlights.map(highlight => (
+                <Badge key={highlight} variant="tech">
+                  {highlight}
+                </Badge>
+              ))}
             </div>
 
             <nav
@@ -101,16 +111,15 @@ export default function HomePage() {
               Profile
             </p>
             <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-4xl">
-              Cloud, identity, and platform reliability
+              Reliability, diagnostics, and reusable tooling
             </h2>
             <div className="mt-5 space-y-3 text-[color:var(--color-text-secondary)] leading-7">
-              {profile.summary.map(p => (
+              {profileLeads.map(p => (
                 <p key={p}>{p}</p>
               ))}
             </div>
             <p className="mt-5 max-w-2xl text-[color:var(--color-text-secondary)] leading-7">
-              I prefer tight feedback loops: infrastructure as code, GitOps, dashboards that answer
-              questions, and interfaces that stay readable under pressure.
+              I convert incident patterns into workflows with clearer ownership and less ambiguity.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
               {githubHref ? (
@@ -208,8 +217,7 @@ export default function HomePage() {
           <div>
             <h2 className="text-3xl font-semibold tracking-tight">Selected work</h2>
             <p className="mt-3 max-w-2xl text-[color:var(--color-text-secondary)] leading-7">
-              Start here: recent projects that show product thinking, platform ownership, and
-              measurable operational outcomes.
+              Flagships are PipelineHealer and SignalForge. Platform work is supporting depth.
             </p>
           </div>
           <Link
@@ -280,8 +288,8 @@ export default function HomePage() {
           <div>
             <h2 className="text-3xl font-semibold tracking-tight">Experience</h2>
             <p className="mt-3 max-w-2xl text-[color:var(--color-text-secondary)] leading-7">
-              A reliability-first track record across identity platforms and cloud-native
-              operations.
+              A reliability-first track record in cloud-native operations, CI/CD, and incident
+              response.
             </p>
           </div>
           {linkedinHref ? (
@@ -347,8 +355,7 @@ export default function HomePage() {
           <div>
             <h2 className="text-3xl font-semibold tracking-tight">Capabilities</h2>
             <p className="mt-3 max-w-2xl text-[color:var(--color-text-secondary)] leading-7">
-              The point is not tool collection. It is the small set of skills that lets me own a
-              system from deployment through troubleshooting.
+              The point is ownership: one system from deployment to incident response.
             </p>
           </div>
           <div className="hidden text-sm text-[color:var(--color-text-secondary)] opacity-80 md:block">
@@ -431,7 +438,8 @@ export default function HomePage() {
           <div>
             <h2 className="text-3xl font-semibold tracking-tight">Writing</h2>
             <p className="mt-3 max-w-2xl text-[color:var(--color-text-secondary)] leading-7">
-              Short, practical notes. The goal is to make my thinking reviewable.
+              Short, practical notes from production systems. Each post records evidence and
+              trade-offs.
             </p>
           </div>
           <Link

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -222,7 +222,7 @@ export default function Header() {
             </div>
 
             <p className="mt-6 text-xs leading-5 text-[color:var(--color-text-secondary)] opacity-80">
-              Short, high-signal notes. Production-first engineering. Documentation over vibes.
+              Short, high-signal notes on production-safe tooling. AI supports, systems decide.
             </p>
           </div>
         </div>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -30,6 +30,24 @@ export const projects: Project[] = [
     id: 7,
   },
   {
+    title: 'SignalForge',
+    slug: 'signalforge',
+    description:
+      'Evidence-first infrastructure diagnostics for production teams. Produces deterministic findings and operator-ready AI explanation for prioritization.',
+    longDescription: `Operator-first infrastructure diagnostics for platform reliability.
+
+- Ingests infrastructure evidence artifacts with strong validation
+- Produces deterministic findings for comparison and replay
+- Adds one constrained AI pass for explanation and triage prioritization
+- Keeps remediation out of scope while trust boundaries are established`,
+    image: '/images/rocketchat-logs-viewer-web-ui.png',
+    tags: ['Python', 'React', 'TypeScript', 'Observability', 'OpenTelemetry', 'LLM'],
+    category: 'DevOps',
+    featured: true,
+    source: 'https://github.com/Canepro/signalforge',
+    id: 9,
+  },
+  {
     title: 'Rocket.Chat Logs Viewer App',
     slug: 'rocketchat-app-logs-viewer',
     description:
@@ -43,7 +61,7 @@ export const projects: Project[] = [
     image: '/images/rocketchat-logs-viewer-web-ui.png',
     tags: ['Rocket.Chat', 'TypeScript', 'Node.js', 'React', 'Vite', 'Tailwind', 'Loki', 'RBAC'],
     category: 'Backend',
-    featured: true,
+    featured: false,
     source: 'https://github.com/Canepro/rocketchat-app-logs-viewer',
     id: 8,
   },
@@ -61,7 +79,7 @@ export const projects: Project[] = [
     image: '/images/ArgoCD_set-up.png',
     tags: ['OCI', 'OKE', 'K3s', 'Terraform', 'ArgoCD', 'GitOps', 'Helm', 'Kustomize', 'LGTM'],
     category: 'Cloud',
-    featured: true,
+    featured: false,
     source: 'https://github.com/Canepro/central-observability-hub-stack/tree/main/argocd',
     visit: 'https://argocd.canepro.me',
     id: 5,
@@ -132,7 +150,7 @@ export const projects: Project[] = [
       'Grafana',
     ],
     category: 'Cloud',
-    featured: true,
+    featured: false,
     source: 'https://github.com/Canepro/rocketchat-k8s',
     visit: 'https://k8.canepro.me',
     id: 0,
@@ -160,7 +178,7 @@ export const projects: Project[] = [
       'NATS',
     ],
     category: 'DevOps',
-    featured: true,
+    featured: false,
     source: 'https://github.com/Canepro/central-observability-hub-stack/tree/main/argocd',
     visit: 'https://argocd.canepro.me',
     id: 6,
@@ -180,7 +198,7 @@ export const projects: Project[] = [
     image: '/images/rocketchat-analyzer.png',
     tags: ['Python', 'Flask', 'Automation', 'Data Analysis', 'Docker'],
     category: 'DevOps',
-    featured: true,
+    featured: false,
     source: 'https://github.com/Canepro/rocketchat-log-analyzer',
     visit: 'https://github.com/Canepro/rocketchat-log-analyzer',
     id: 1,

--- a/src/constants/projectDetails.ts
+++ b/src/constants/projectDetails.ts
@@ -57,6 +57,61 @@ That framing is much closer to how automation has to behave in real delivery sys
       Deployment: ['Azure Container Apps', 'Docker/Podman', 'Helm/Kubernetes'],
     },
   },
+  signalforge: {
+    slug: 'signalforge',
+    longDescription: `## Overview
+
+SignalForge is an **operator-first infrastructure diagnostics system**.
+
+The design is deliberate:
+
+1. Ingest evidence artifacts from observability and platform systems.
+2. Normalize what is known into deterministic findings.
+3. Use a constrained AI pass only for explanation, prioritization, and context.
+4. Keep remediation out of scope until confidence and safety gates are explicit.
+
+## What it is designed for
+
+- reduce repeated ambiguity in incident follow-up
+- compare structured diagnostic signals across environments quickly
+- produce operator-facing findings with a clear source trail
+- support bounded automation decisions instead of broad model autonomy
+
+## Why this is a flagship line
+
+The project pushes the same trust model used in production systems:
+
+- deterministic facts are primary, model output is secondary
+- evidence objects are normalized before they are explained
+- operator choice remains the control point for impactful actions
+
+## Source
+
+- **Repository:** https://github.com/Canepro/signalforge
+
+SignalForge is positioned as the diagnostics-first sibling to PipelineHealer, with a narrower action boundary and stronger explainability focus.`,
+    challenges: [
+      'Turning messy evidence streams into comparable diagnostics without adding noise',
+      'Making findings explainable enough to speed operator decision-making',
+      'Keeping model output constrained to support trust and reversibility',
+      'Avoiding silent scope creep between diagnostics and remediation paths',
+    ],
+    solutions: [
+      'Built a strict evidence ingest and normalisation path before any AI enrichment',
+      'Separated deterministic findings from LLM explanation and prioritization',
+      'Added bounded explanation pass with explicit trust boundaries',
+      'Designed workflows so operators remain in control of escalation and action decisions',
+    ],
+    impact:
+      'Introduces a product-style diagnostics line with reproducible outputs and explicit operator control, demonstrating reusable tooling for incident handling without replacing human decision authority.',
+    technologies: {
+      Backend: ['Python'],
+      Frontend: ['React', 'TypeScript'],
+      AI: ['LLM (constrained pass)'],
+      Observability: ['OpenTelemetry'],
+      Platform: ['OTLP ingestion', 'Structured diagnostics artifacts'],
+    },
+  },
   'rocketchat-app-logs-viewer': {
     slug: 'rocketchat-app-logs-viewer',
     longDescription: `## Overview

--- a/src/content/profile.ts
+++ b/src/content/profile.ts
@@ -2,7 +2,7 @@ export const profile = {
   name: 'Vincent Mogah',
   // Keep this aligned with the latest LinkedIn headline (but trimmed for readability).
   headline:
-    'Azure Infrastructure & Cloud Engineer | DevOps | Microsoft 365 & Entra ID | PowerShell Automation | ITIL',
+    'AI-native Reliability Engineer | Product-minded Platform Builder | Diagnostics & Remediation Tooling',
   location: 'United Kingdom',
   email: 'mogah.vincent@hotmail.com',
   links: {
@@ -11,8 +11,8 @@ export const profile = {
     twitter: 'https://twitter.com/Canepro',
   },
   summary: [
-    'Cloud Engineer and DevOps professional focused on dependable systems, automation, and secure delivery.',
-    'Experienced with CI/CD, infrastructure as code (Terraform), container platforms (Docker/Kubernetes), and GitOps (Argo CD).',
-    'I optimize for reliability, observability, and removing operational friction through runbooks and scripted workflows.',
+    'I build reliability systems that turn recurring pain into reusable diagnostics.',
+    'I ship tooling with deterministic defaults, evidence-first triage, and bounded AI.',
+    'Recent work focuses on product-quality systems for remediation, diagnostics, and operator confidence.',
   ],
 } as const;

--- a/src/content/skills.ts
+++ b/src/content/skills.ts
@@ -34,6 +34,7 @@ export const skillGroups: SkillGroup[] = [
     evidence: [
       { label: 'Observability Hub', href: '/projects/central-observability-hub-stack' },
       { label: 'Rocket.Chat on K8s', href: '/projects/rocketchat-kubernetes-enterprise' },
+      { label: 'SignalForge', href: '/projects/signalforge' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Repositions homepage narrative to emphasize AI-native reliability, diagnostics, and operator tooling.
- Updates hero, profile intro, and selected work framing to foreground PipelineHealer and SignalForge.
- Adds SignalForge as featured project and keeps platform projects in supporting role.
- Adds dedicated project detail for SignalForge.

## Verification
- bun run lint
- bun run typecheck
- bun run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed site messaging and professional positioning from infrastructure/DevOps focus to AI-native reliability engineering.
  * Introduced new SignalForge project showcase with comprehensive details and technologies overview.
  * Updated featured projects and hero badges to reflect current focus areas.
  * Refreshed copy across key sections including About, hero, header tagline, and experience descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->