### PR TITLE
Portfolio polish: anti-AI dash sweep and fix SignalForge project image

### DIFF
--- a/content/blog/2026-02-07-gitops-notes.mdx
+++ b/content/blog/2026-02-07-gitops-notes.mdx
@@ -1,17 +1,17 @@
 ---
 title: "GitOps Notes: The Parts That Actually Matter"
 date: "2026-02-07"
-description: "A practical mental model for GitOps beyond the buzzwords — drawn from running ArgoCD across OCI and Azure."
+description: "A practical mental model for GitOps beyond the buzzwords, drawn from running ArgoCD across OCI and Azure."
 tags: ["gitops", "argocd", "kubernetes", "ci-cd"]
 ---
 
-GitOps is less about tools and more about **control loops**. After running ArgoCD across two clusters — an [OKE hub on OCI](/projects/hybrid-cloud-gitops-control-plane) and an [AKS spoke on Azure](/projects/rocketchat-kubernetes-enterprise) — these are the patterns that actually held up.
+GitOps is less about tools and more about **control loops**. After running ArgoCD across two clusters, an [OKE hub on OCI](/projects/hybrid-cloud-gitops-control-plane) and an [AKS spoke on Azure](/projects/rocketchat-kubernetes-enterprise), these are the patterns that actually held up.
 
 ## The Mental Model
 
 1. **Desired state lives in Git.** Every Helm values file, every Kustomize overlay, every namespace definition. If it is not in the repo, it does not exist.
 2. **A reconciler continuously compares desired vs actual.** ArgoCD watches the repo and diffs against the live cluster. This is where drift becomes visible.
-3. **Drift is correctable, not catastrophic.** A misconfigured resource is not a crisis — it is a PR away from being fixed.
+3. **Drift is correctable, not catastrophic.** A misconfigured resource is not a crisis. It is a PR away from being fixed.
 
 The key insight: GitOps is not "infrastructure as code." It is *infrastructure as a feedback loop*. The value is not in storing YAML in Git; it is in the reconciler closing the gap automatically.
 
@@ -19,26 +19,26 @@ The key insight: GitOps is not "infrastructure as code." It is *infrastructure a
 
 On the [Hybrid Cloud GitOps Control Plane](/projects/hybrid-cloud-gitops-control-plane), the separation looks like this:
 
-- **Hub cluster (OKE)** — runs ArgoCD, the LGTM observability stack, and platform services. Terraform provisions the infrastructure; ArgoCD manages everything above the node level.
-- **Spoke cluster (AKS/K3s)** — runs application workloads like Rocket.Chat. ArgoCD on the hub syncs manifests to the spoke via cluster secrets.
-- **CI pipeline (Jenkins)** — validates changes *before* they reach Git. Lint, typecheck, build, Dockerfile lint, container build — all without pushing images on PRs. ArgoCD only sees commits that already passed CI.
+- **Hub cluster (OKE)**: runs ArgoCD, the LGTM observability stack, and platform services. Terraform provisions the infrastructure; ArgoCD manages everything above the node level.
+- **Spoke cluster (AKS/K3s)**: runs application workloads like Rocket.Chat. ArgoCD on the hub syncs manifests to the spoke via cluster secrets.
+- **CI pipeline (Jenkins)**: validates changes *before* they reach Git. Lint, typecheck, build, Dockerfile lint, container build, all without pushing images on PRs. ArgoCD only sees commits that already passed CI.
 
 This means a deployment is: merge a PR, ArgoCD syncs, done. A rollback is: revert the PR, ArgoCD syncs, done.
 
 ## Practical Checklist
 
-- **Separate platform from apps.** Different repos or at minimum different directory trees. The [observability hub](/projects/central-observability-hub-stack) and [Rocket.Chat deployment](/projects/rocketchat-kubernetes-enterprise) live in separate repos for a reason — different change cadences, different blast radii.
+- **Separate platform from apps.** Different repos or at minimum different directory trees. The [observability hub](/projects/central-observability-hub-stack) and [Rocket.Chat deployment](/projects/rocketchat-kubernetes-enterprise) live in separate repos for a reason, different change cadences, different blast radii.
 - **Make rollbacks boring.** One revert commit, one sync. If rolling back requires manual steps, your GitOps setup is incomplete.
-- **Pin everything.** Image tags, Helm chart versions, Terraform provider versions. `latest` is not a version — it is a prayer.
+- **Pin everything.** Image tags, Helm chart versions, Terraform provider versions. `latest` is not a version. It is a prayer.
 - **Treat repo access like production access.** Branch protection, required reviews, signed commits if you can. The Git repo *is* your control plane.
 - **Validate before merge, not after.** CI should catch misconfigurations before ArgoCD ever sees them. This is why the Jenkins pipeline runs hadolint and a full container build on every PR.
 - **Monitor the reconciler, not just the workloads.** If ArgoCD is unhealthy, you have lost your feedback loop. The [observability stack](/projects/central-observability-hub-stack) watches ArgoCD sync status alongside application metrics.
 
 ## The Anti-Patterns
 
-1. **"We do GitOps" but deployments still require `kubectl apply`.** If a human is running commands against the cluster, it is not GitOps — it is Git-adjacent.
+1. **"We do GitOps" but deployments still require `kubectl apply`.** If a human is running commands against the cluster, it is not GitOps. It is Git-adjacent.
 2. **One giant mono-repo for everything.** Works for small teams, breaks when platform and app teams have different review cycles.
-3. **Skipping the CI gate.** ArgoCD will happily sync broken manifests. The reconciler does not validate — it applies.
+3. **Skipping the CI gate.** ArgoCD will happily sync broken manifests. The reconciler does not validate. It applies.
 
 ## Takeaway
 

--- a/content/blog/2026-02-07-welcome.mdx
+++ b/content/blog/2026-02-07-welcome.mdx
@@ -11,21 +11,21 @@ I built this portfolio to answer a simple question:
 
 Projects show outcomes. A blog shows *how you think*.
 
-This site is a Next.js app with TypeScript, statically built and deployed to Netlify. The infrastructure behind it — Jenkins pipelines on Kubernetes, a [hub-and-spoke observability stack](/projects/central-observability-hub-stack), GitOps with ArgoCD — is the same stack I write about here. The blog is not separate from the work; it is part of it.
+This site is a Next.js app with TypeScript, statically built and deployed to Netlify. The infrastructure behind it, Jenkins pipelines on Kubernetes, a [hub-and-spoke observability stack](/projects/central-observability-hub-stack), GitOps with ArgoCD, is the same stack I write about here. The blog is not separate from the work; it is part of it.
 
 ## What You'll See Here
 
-- **Build notes** — tradeoffs, constraints, and the boring-but-important details behind projects like the [Hybrid Cloud GitOps Control Plane](/projects/hybrid-cloud-gitops-control-plane) and [Rocket.Chat on AKS](/projects/rocketchat-kubernetes-enterprise)
-- **DevOps and platform engineering** — Kubernetes, GitOps, observability pipelines, CI/CD. Real patterns from running workloads across OCI and Azure, not contrived examples
-- **Frontend engineering** — performance, accessibility, UI architecture. This portfolio itself is the proving ground (see the [Systems](/systems) page for a live architecture diagram)
+- **Build notes**: tradeoffs, constraints, and the boring-but-important details behind projects like the [Hybrid Cloud GitOps Control Plane](/projects/hybrid-cloud-gitops-control-plane) and [Rocket.Chat on AKS](/projects/rocketchat-kubernetes-enterprise)
+- **DevOps and platform engineering**: Kubernetes, GitOps, observability pipelines, CI/CD. Real patterns from running workloads across OCI and Azure, not contrived examples
+- **Frontend engineering**: performance, accessibility, UI architecture. This portfolio itself is the proving ground (see the [Systems](/systems) page for a live architecture diagram)
 
 ## How Posts Are Structured
 
 Each post follows a pattern:
 
-1. **Context** — what problem I was solving and why it matters
-2. **The approach** — what I tried, what I rejected, and what I shipped
-3. **The takeaway** — a checklist, snippet, or reusable pattern you can apply to your own work
+1. **Context**: what problem I was solving and why it matters
+2. **The approach**: what I tried, what I rejected, and what I shipped
+3. **The takeaway**: a checklist, snippet, or reusable pattern you can apply to your own work
 
 No filler. If a post does not end with something you can re-use, it should not exist.
 

--- a/content/blog/2026-02-10-pipelinehealer-hackathon-start.mdx
+++ b/content/blog/2026-02-10-pipelinehealer-hackathon-start.mdx
@@ -1,11 +1,11 @@
 ---
 title: "PipelineHealer: An AI Agent That Fixes CI/CD Failures"
 date: "2026-02-10"
-description: "Building a multi-agent system that detects, diagnoses, and remediates broken pipelines — for the AI Dev Days Hackathon."
+description: "Building a multi-agent system that detects, diagnoses, and remediates broken pipelines, for the AI Dev Days Hackathon."
 tags: ["hackathon", "ai-agents", "devops", "azure", "github-actions"]
 ---
 
-CI/CD failures follow a predictable loop: pipeline goes red, someone scrolls through logs, finds the error, context-switches to fix it, pushes, waits. Steps two through five are repetitive and interruptible. They do not require a human — they require pattern matching and a structured response.
+CI/CD failures follow a predictable loop: pipeline goes red, someone scrolls through logs, finds the error, context-switches to fix it, pushes, waits. Steps two through five are repetitive and interruptible. They do not require a human. They require pattern matching and a structured response.
 
 **PipelineHealer** automates the repetitive part of that loop. A GitHub webhook fires on a failed workflow run, the system analyzes the failure, and PipelineHealer either opens a fix PR for deterministic cases or files a structured issue when confidence is low.
 
@@ -13,38 +13,38 @@ This is my entry for the [AI Dev Days Hackathon](https://github.com/Azure/AI-Dev
 
 ## Why Multi-Agent
 
-The single-prompt approach — "here are 500 lines of CI logs, fix it" — produces inconsistent results. The context is too broad, the task is too vague, and the output oscillates between useful and hallucinated.
+The single-prompt approach, "here are 500 lines of CI logs, fix it", produces inconsistent results. The context is too broad, the task is too vague, and the output oscillates between useful and hallucinated.
 
 Breaking the problem into four focused agents changed the reliability entirely:
 
-1. **Log Analyzer** — parses raw output, extracts structured error patterns. Does not diagnose.
-2. **Diagnosis Agent** — maps extracted patterns to early failure categories: dependency issues, lint/format failures, test failures, build config errors, and timeouts. Does not fix.
-3. **Remediation Agent** — generates a targeted fix based on a confirmed diagnosis. Does not guess from raw logs.
-4. **Orchestrator** — coordinates the pipeline, manages state, opens the PR or issue.
+1. **Log Analyzer**: parses raw output, extracts structured error patterns. Does not diagnose.
+2. **Diagnosis Agent**: maps extracted patterns to early failure categories: dependency issues, lint/format failures, test failures, build config errors, and timeouts. Does not fix.
+3. **Remediation Agent**: generates a targeted fix based on a confirmed diagnosis. Does not guess from raw logs.
+4. **Orchestrator**: coordinates the pipeline, manages state, opens the PR or issue.
 
 Each agent has a narrow scope, structured inputs and outputs, and can be tested independently. The agents communicate through typed data models, not free-form text.
 
 ## The Stack
 
-- **Agents** — Microsoft Agent Framework workflows, Azure OpenAI
-- **Backend** — Python, FastAPI
-- **Frontend** — React, TypeScript, Tailwind, TanStack Query
-- **Storage** — Azure Cosmos DB (serverless)
-- **Hosting** — Azure Container Apps
-- **Trigger** — GitHub `workflow_run.completed` webhook
+- **Agents**: Microsoft Agent Framework workflows, Azure OpenAI
+- **Backend**: Python, FastAPI
+- **Frontend**: React, TypeScript, Tailwind, TanStack Query
+- **Storage**: Azure Cosmos DB (serverless)
+- **Hosting**: Azure Container Apps
+- **Trigger**: GitHub `workflow_run.completed` webhook
 
 The flow: GitHub sends the webhook → the backend validates and persists the failed run → the agent pipeline runs → a PR or issue is created on the source repo. The launch scope covered five core failure types.
 
 ## What's Built
 
-The scaffold is done — agents, GitHub integration, webhook handler, dashboard frontend, Docker setup. Next phase is production hardening and Azure deployment, including live webhook wiring and real-failure validation.
+The scaffold is done, agents, GitHub integration, webhook handler, dashboard frontend, Docker setup. Next phase is production hardening and Azure deployment, including live webhook wiring and real-failure validation.
 
 ## What's Coming
 
 This is post one of six. The series will cover:
 
 - Architecture decisions behind the agent pipeline
-- Deploying to Azure — failure modes discovered during deployment and mitigations
+- Deploying to Azure, failure modes discovered during deployment and mitigations
 - Prompt engineering for CI log parsing
 - End-to-end walkthrough from webhook to pull request
 - Retrospective after submission

--- a/content/blog/2026-03-03-pipelinehealer-webhook-to-pull-request.mdx
+++ b/content/blog/2026-03-03-pipelinehealer-webhook-to-pull-request.mdx
@@ -1,7 +1,7 @@
 ---
 title: "From Webhook to Pull Request: The Full Healing Loop (Including the Parts That Surprised Me)"
 date: "2026-03-03"
-description: "A concrete walkthrough of PipelineHealer processing a real CI failure — from webhook delivery through diagnosis, external diagnostics, remediation, and the backfill system I didn't plan to build."
+description: "A concrete walkthrough of PipelineHealer processing a real CI failure, from webhook delivery through diagnosis, external diagnostics, remediation, and the backfill system I didn't plan to build."
 tags: ["hackathon", "ai-agents", "ci-cd", "github-actions", "azure", "devops", "observability"]
 ---
 
@@ -11,7 +11,7 @@ That sounds clean. Getting there was not.
 
 ![PipelineHealer dashboard showing 81 processed activities, safety gating ratios, and explainability snapshot](/images/Pipelinehealer-dashboard.png)
 
-This post traces the actual execution path of that run — every step from webhook to merged output — and covers an entire subsystem I had to build because external diagnostics do not arrive on your schedule.
+This post traces the actual execution path of that run, every step from webhook to merged output, and covers an entire subsystem I had to build because external diagnostics do not arrive on your schedule.
 
 Current project baseline is `v0.3.0`, which adds Activity Detail `Copy Context` and a visible `Assign to Agent` (`Coming Soon`) handoff affordance. This write-up focuses on the webhook-to-remediation reliability path that underpins those UX layers.
 
@@ -25,7 +25,7 @@ I ran this from my terminal:
 gh workflow run CI --repo Canepro/pipelinehealer-demo --field failure_type=dependency
 ```
 
-The demo repo's CI workflow has a dispatch input that injects a specific failure. For `dependency`, it adds `left-pad@999.0.0` to `package.json` — a version that does not exist. The workflow fails at `npm install`.
+The demo repo's CI workflow has a dispatch input that injects a specific failure. For `dependency`, it adds `left-pad@999.0.0` to `package.json`, a version that does not exist. The workflow fails at `npm install`.
 
 GitHub fires a `workflow_run.completed` webhook to PipelineHealer's backend on Azure Container Apps.
 
@@ -33,10 +33,10 @@ GitHub fires a `workflow_run.completed` webhook to PipelineHealer's backend on A
 
 The webhook handler is the first filter. Before any agent work happens, it checks:
 
-1. **Signature verification** — HMAC-SHA256 against `GITHUB_WEBHOOK_SECRET`. Invalid signatures get a `401` immediately.
-2. **Event type** — only `workflow_run` events with `conclusion: failure` proceed. Successful runs, in-progress runs, and non-workflow events are ignored.
-3. **Repo allowlist** — `PH_ALLOWED_REPOS` is enforced here. If the source repo is not on the list, the event is dropped with a reason code. This prevents the PAT from being used against unintended repositories.
-4. **Idempotency** — duplicate `workflow_run` IDs are caught before creating a new activity.
+1. **Signature verification**: HMAC-SHA256 against `GITHUB_WEBHOOK_SECRET`. Invalid signatures get a `401` immediately.
+2. **Event type**: only `workflow_run` events with `conclusion: failure` proceed. Successful runs, in-progress runs, and non-workflow events are ignored.
+3. **Repo allowlist**: `PH_ALLOWED_REPOS` is enforced here. If the source repo is not on the list, the event is dropped with a reason code. This prevents the PAT from being used against unintended repositories.
+4. **Idempotency**: duplicate `workflow_run` IDs are caught before creating a new activity.
 
 If all gates pass, an `ActivityRecord` is created with status `processing` and the orchestrator takes over.
 
@@ -44,7 +44,7 @@ If all gates pass, an `ActivityRecord` is created with status `processing` and t
 
 The orchestrator's first step is fetching the failure data.
 
-PipelineHealer calls the GitHub API to get the workflow run's jobs, then fetches logs for each failed job. The raw log output is structured into error lines, warning lines, key events, and a compact summary. This is the Log Analyzer agent's only job — extraction, not diagnosis.
+PipelineHealer calls the GitHub API to get the workflow run's jobs, then fetches logs for each failed job. The raw log output is structured into error lines, warning lines, key events, and a compact summary. This is the Log Analyzer agent's only job, extraction, not diagnosis.
 
 For this run, the extracted signal was clear:
 
@@ -64,7 +64,7 @@ Result:
 - **Failure type**: `dependency`
 - **Auto-fixable**: yes
 
-No LLM call was needed. The model fallback exists for ambiguous cases — test failures with unclear assertions, config errors in unfamiliar build tools — but for known patterns, deterministic wins every time.
+No LLM call was needed. The model fallback exists for ambiguous cases, test failures with unclear assertions, config errors in unfamiliar build tools, but for known patterns, deterministic wins every time.
 
 This is one of the design decisions I keep reinforcing: pattern-first, model-second. Every failure type that can be resolved with string matching should be.
 
@@ -89,7 +89,7 @@ But there is another actor in the system.
 
 ## ci-doctor: The External Diagnostic That Runs on Its Own Clock
 
-When GitHub Agentic Workflows are installed on a repository, `ci-doctor` fires automatically on `workflow_run` failures. It is an independent AI analysis workflow maintained by GitHub — separate from PipelineHealer.
+When GitHub Agentic Workflows are installed on a repository, `ci-doctor` fires automatically on `workflow_run` failures. It is an independent AI analysis workflow maintained by GitHub, separate from PipelineHealer.
 
 PipelineHealer treats `ci-doctor` as an optional, additive signal. In this run, integration mode was passive: PipelineHealer never dispatched `ci-doctor`; it only checked whether findings existed after the fact.
 
@@ -106,7 +106,7 @@ Here is where I hit a real problem.
 
 `ci-doctor` takes time. It fetches logs, runs its own AI analysis, and publishes an issue. For my test run, PipelineHealer's diagnosis completed in under 2 minutes. `ci-doctor` was still running 11 minutes later.
 
-PipelineHealer's bounded polling window expired. It stored a `poll_window_exhausted` status for external diagnostics and continued with its own native diagnosis — which was already sufficient.
+PipelineHealer's bounded polling window expired. It stored a `poll_window_exhausted` status for external diagnostics and continued with its own native diagnosis, which was already sufficient.
 
 But that meant the dashboard showed "External diagnostics: poll window exhausted" even after `ci-doctor` eventually published [Issue #89](https://github.com/Canepro/pipelinehealer-demo/issues/89) with a thorough analysis.
 
@@ -133,25 +133,25 @@ This was not in the original plan. I built it because the E2E test showed me a r
 
 The first version of external diagnostics stored a link to the `ci-doctor` issue and some metadata. Useful, but shallow.
 
-I wanted the dashboard to show what `ci-doctor` actually found — not just that it found something.
+I wanted the dashboard to show what `ci-doctor` actually found, not just that it found something.
 
 So I added structured extraction from `ci-doctor` issue bodies. The parser pulls out:
 
-- **Summary** — one-line problem statement
-- **Root cause** — detailed analysis
-- **Recommended actions** — specific fix steps
-- **Historical context** — related failures and patterns
-- **Doctor metadata** — which AI engine and model produced the diagnosis
+- **Summary**: one-line problem statement
+- **Root cause**: detailed analysis
+- **Recommended actions**: specific fix steps
+- **Historical context**: related failures and patterns
+- **Doctor metadata**: which AI engine and model produced the diagnosis
 
 These fields are stored in `external_diagnostics[].metadata.details` on the activity record.
 
-There was a catch: `ci-doctor` issue bodies include internal boilerplate — HTML comments, AI attribution footers, setup hints, expiry markers, temp-file paths. All of that needed to be stripped before storage. I wrote a sanitizer with regex patterns for each category of noise. Then I wrote tests for the sanitizer, because regex sanitizers are the kind of code that breaks silently.
+There was a catch: `ci-doctor` issue bodies include internal boilerplate, HTML comments, AI attribution footers, setup hints, expiry markers, temp-file paths. All of that needed to be stripped before storage. I wrote a sanitizer with regex patterns for each category of noise. Then I wrote tests for the sanitizer, because regex sanitizers are the kind of code that breaks silently.
 
 ## The External Findings Panel
 
 With structured data available, the frontend needed a way to render it.
 
-I added a collapsible "External Findings Details" panel inside the activity detail view. It renders each extracted section with proper formatting — bullet lists, inline code, bold text, links — instead of raw whitespace. Long sections are truncated with "Show more" to keep the card scannable.
+I added a collapsible "External Findings Details" panel inside the activity detail view. It renders each extracted section with proper formatting, bullet lists, inline code, bold text, links, instead of raw whitespace. Long sections are truncated with "Show more" to keep the card scannable.
 
 The panel auto-expands when the diagnostic status is `available` and details exist. If the diagnostic is still `poll_window_exhausted` or errored, it stays collapsed. Users can always expand or collapse manually.
 
@@ -167,9 +167,9 @@ For the E2E run that validated all of this, the activity detail page showed:
 - **PR link**: [#91](https://github.com/Canepro/pipelinehealer-demo/pull/91)
 - **Issue link**: [#90](https://github.com/Canepro/pipelinehealer-demo/issues/90)
 - **External diagnostics**: available (ci-doctor)
-- **External findings panel**: summary, root cause, recommended actions, historical context — all rendered cleanly
+- **External findings panel**: summary, root cause, recommended actions, historical context, all rendered cleanly
 
-![External Findings Details panel showing ci-doctor's structured analysis — summary, root cause, recommended actions, historical context, and AI metadata badges](/images/external-diagnostics.png)
+![External Findings Details panel showing ci-doctor's structured analysis, summary, root cause, recommended actions, historical context, and AI metadata badges](/images/external-diagnostics.png)
 
 That is the full loop. Webhook to PR, with an independent AI second opinion enriching the record after the fact.
 
@@ -184,11 +184,11 @@ If I had only tested components in isolation, I would have shipped a system that
 - stored raw `ci-doctor` boilerplate in the database (bad)
 - rendered internal HTML comments in the UI (bad)
 
-Every one of those gaps was caught by a real run against the deployed system. The lesson is not "test more" — it is "test the thing users will actually see."
+Every one of those gaps was caught by a real run against the deployed system. The lesson is not "test more", it is "test the thing users will actually see."
 
 ## Reusable Takeaway Checklist
 
-- Gate webhooks early: signature, event type, repo allowlist, idempotency — before any compute.
+- Gate webhooks early: signature, event type, repo allowlist, idempotency, before any compute.
 - Extract structure before diagnosis. Never pass raw logs to a decision agent.
 - Use deterministic pattern matching first. Reserve model calls for genuine ambiguity.
 - Treat external tool integration as eventual-consistency, not request-response.

--- a/content/blog/2026-03-16-pipelinehealer-hackathon-retrospective.mdx
+++ b/content/blog/2026-03-16-pipelinehealer-hackathon-retrospective.mdx
@@ -29,7 +29,7 @@ This was the single best architectural decision.
 
 The instinct with an AI hackathon project is to put the model at the center of everything. I almost did. Early prototypes sent full log dumps to GPT and asked for fixes. The results were inconsistent and hard to debug.
 
-Flipping the order — deterministic pattern matching first, LLM fallback only for ambiguity — made the system predictable.
+Flipping the order, deterministic pattern matching first, LLM fallback only for ambiguity, made the system predictable.
 
 Benefits:
 - Dependency failures, lint errors, and build config issues are resolved without a model call.
@@ -38,13 +38,13 @@ Benefits:
 
 ### 2. Typed contracts between agents
 
-Every agent-to-agent handoff is a Pydantic model. `LogAnalysis`, `Diagnosis`, `RemediationPlan` — all typed, all validatable, all testable without running the full pipeline.
+Every agent-to-agent handoff is a Pydantic model. `LogAnalysis`, `Diagnosis`, `RemediationPlan`, all typed, all validatable, all testable without running the full pipeline.
 
 This sounds obvious. In practice, most multi-agent demos I have seen pass free-form text between agents and hope for the best. Typed contracts prevented an entire class of "agent 2 misunderstood agent 1" bugs.
 
 ### 3. One-command operator interface
 
-I built `scripts/ph.sh` as a single entrypoint for every operation: deploy, demo, scale, logs, settings, backfill. This was not in the original plan — I added it after getting tired of re-reading runbooks for common tasks.
+I built `scripts/ph.sh` as a single entrypoint for every operation: deploy, demo, scale, logs, settings, backfill. This was not in the original plan, I added it after getting tired of re-reading runbooks for common tasks.
 
 It turned out to be one of the most useful things in the project. During demo recording, I could run `bash scripts/ph.sh warm` before starting and `bash scripts/ph.sh lowcost` after. During debugging, `bash scripts/ph.sh logs:grep --pattern "error"` replaced multiple Azure CLI incantations.
 
@@ -52,7 +52,7 @@ If I were advising someone on a hackathon project: build your operator CLI early
 
 ### 4. Treating deployment as product work
 
-I deployed to Azure on day three — before the agents were polished, before the dashboard was pretty, before half the features existed. This was uncomfortable but correct.
+I deployed to Azure on day three, before the agents were polished, before the dashboard was pretty, before half the features existed. This was uncomfortable but correct.
 
 Deploying early surfaced identity issues, proxy failures, webhook configuration mistakes, and cold-start behavior that I never would have found locally. Every one of those became a lesson that shaped the final system. [Post 3 in this series](/blog/2026-02-12-pipelinehealer-azure-deployment-lessons) covers the specific failures, but the meta-lesson is: if your project runs on cloud infrastructure, deploy to that infrastructure immediately. Do not wait until "the code is ready."
 
@@ -70,7 +70,7 @@ Integrating GitHub's `ci-doctor` agentic workflow taught me something I should h
 
 PipelineHealer completes diagnosis in 1-2 minutes. `ci-doctor` can take 10-20 minutes. During this incident, an ~8-minute polling window was not enough, so the system correctly fell back to native diagnosis while external findings arrived later.
 
-I ended up building a full backfill subsystem — background sweep, manual endpoint, CLI command, UI button — to handle late-arriving diagnostics. That entire subsystem was not in the plan. It exists because I ran a real E2E test and watched the gap happen.
+I ended up building a full backfill subsystem, background sweep, manual endpoint, CLI command, UI button, to handle late-arriving diagnostics. That entire subsystem was not in the plan. It exists because I ran a real E2E test and watched the gap happen.
 
 By `v0.2.9`, this path matured into a hybrid model:
 - fast-path polling defaults to 60 seconds
@@ -91,13 +91,13 @@ Third-party content is never clean. Budget time for sanitization.
 
 ### 3. Documentation is a forcing function
 
-I wrote six blog posts during the hackathon. That was not originally planned as part of the build — I did it because the hackathon judges value documented thinking, and because my portfolio site needed content.
+I wrote six blog posts during the hackathon. That was not originally planned as part of the build, I did it because the hackathon judges value documented thinking, and because my portfolio site needed content.
 
 What I did not expect: writing about the system forced me to clarify decisions I had been hand-waving. The diagnostics wait policy and its rationale are easy to gloss over in code but impossible to skip in a blog post. Every post made the system slightly better because it made me justify choices out loud.
 
 ### 4. The CLI became the most-used interface
 
-I built a dashboard with charts, filters, and an admin settings page. During development, I used the CLI for almost everything. Deploy, check status, inspect logs, trigger backfill, run E2E tests — all from the terminal.
+I built a dashboard with charts, filters, and an admin settings page. During development, I used the CLI for almost everything. Deploy, check status, inspect logs, trigger backfill, run E2E tests, all from the terminal.
 
 The dashboard matters for the demo and for ongoing visibility. But the CLI is what I actually operated with. If I had to choose one, I would build the CLI first and the dashboard second.
 
@@ -113,13 +113,13 @@ The dashboard matters for the demo and for ongoing visibility. But the CLI is wh
 
 I built agents first, then wired them together, then deployed, then tested end-to-end. The right order is the reverse: define the E2E scenario first ("webhook arrives, PR opens"), build the thinnest possible path that achieves it, then improve each step.
 
-Every major insight came from E2E testing. The backfill system, the sanitizer, the polling window tuning, the UI panel design — all of them came from watching the deployed system process a real failure. I would have found these sooner if I had started from the outside in.
+Every major insight came from E2E testing. The backfill system, the sanitizer, the polling window tuning, the UI panel design, all of them came from watching the deployed system process a real failure. I would have found these sooner if I had started from the outside in.
 
 ### 2. Build backfill from day one
 
 Any system that depends on external data arriving within a window needs a backfill mechanism from the start. I treated external diagnostics polling as "poll and move on." That was fine for the primary path but left stale data in the activity record.
 
-The backfill pattern — periodic sweep for incomplete records, re-fetch, patch in place — is generic enough that I should have scaffolded it early and specialized it later.
+The backfill pattern, periodic sweep for incomplete records, re-fetch, patch in place, is generic enough that I should have scaffolded it early and specialized it later.
 
 ### 3. Fewer healing modes
 
@@ -129,7 +129,7 @@ If I started over, I would have `safe` and `debug` only. Two modes are easier to
 
 ### 4. Pin the demo repo fixture set earlier
 
-The demo repository went through several iterations of its CI workflow — adding failure types, changing dispatch inputs, cleaning up dead files. Each time, I had to re-validate the E2E flow.
+The demo repository went through several iterations of its CI workflow, adding failure types, changing dispatch inputs, cleaning up dead files. Each time, I had to re-validate the E2E flow.
 
 I should have frozen the demo fixture set after the first successful E2E run and only added new failure types in planned batches. Incremental fixture changes created unnecessary re-testing cycles.
 
@@ -147,10 +147,10 @@ Some of these numbers moved after the hackathon, so these are the current repo-l
 
 These were real gaps in the `v0.3.0` submission baseline, not aspirational features:
 
-- **Lockfile-aware dependency fixes** — the current dependency remediation edits `package.json` but does not regenerate lockfiles. A production version would need to handle `package-lock.json`, `pnpm-lock.yaml`, and `bun.lockb`.
-- **GitHub App auth** — I used a PAT throughout. The current repo surfaces GitHub App readiness in operator views, but the active GitHub client path still uses a PAT or externally supplied token, so full App-native auth remains unfinished.
-- **Notification delivery channels** — at submission time, diagnostics were strongest in the app and chat delivery to Slack/Teams/Rocket.Chat was still a planned extension for non-admin stakeholders. This later shipped in `v0.5.0` alongside email delivery.
-- **Multi-provider CI support** — at submission time, PipelineHealer was GitHub Actions only. The adapter pattern existed, but GitLab CI and Jenkins adapters were not built. Jenkins bridge support later landed in `v0.3.2`; broader provider coverage is still open.
+- **Lockfile-aware dependency fixes**: the current dependency remediation edits `package.json` but does not regenerate lockfiles. A production version would need to handle `package-lock.json`, `pnpm-lock.yaml`, and `bun.lockb`.
+- **GitHub App auth**: I used a PAT throughout. The current repo surfaces GitHub App readiness in operator views, but the active GitHub client path still uses a PAT or externally supplied token, so full App-native auth remains unfinished.
+- **Notification delivery channels**: at submission time, diagnostics were strongest in the app and chat delivery to Slack/Teams/Rocket.Chat was still a planned extension for non-admin stakeholders. This later shipped in `v0.5.0` alongside email delivery.
+- **Multi-provider CI support**: at submission time, PipelineHealer was GitHub Actions only. The adapter pattern existed, but GitLab CI and Jenkins adapters were not built. Jenkins bridge support later landed in `v0.3.2`; broader provider coverage is still open.
 
 
 ## The Honest Summary

--- a/content/blog/blog.md
+++ b/content/blog/blog.md
@@ -6,8 +6,8 @@
 
 ## Series 1: PipelineHealer Hackathon Journey (7 posts)
 
-The AI Dev Days Hackathon runs Feb 10 – Mar 15, 2026. These posts document the journey
-of building PipelineHealer — an AI-powered multi-agent system that automatically detects,
+The AI Dev Days Hackathon runs Feb 10 to Mar 15, 2026. These posts document the journey
+of building PipelineHealer, an AI-powered multi-agent system that automatically detects,
 diagnoses, and fixes CI/CD pipeline failures.
 
 | #   | Title                                                                      | Target Publish            | Status       |
@@ -30,7 +30,7 @@ Real posts drawn from actual projects and repos.
 | --- | ------------------------------------------------------------------------------------ | ------------------------------------------ | ------- |
 | 8   | Building a Centralized Observability Stack: Prometheus + Grafana Across Environments | `central-observability-hub-stack`          | ❌ TODO |
 | 9   | Rocket.Chat on K3s: Running Enterprise Chat with Prometheus Agent                    | `rocketchat-k8s`                           | ❌ TODO |
-| 10  | I Inherited a Terraform Repo — Here's How I Reviewed and Hardened It                 | `Aws-3tier-Infrastructure-using-Terraform` | ❌ TODO |
+| 10  | I Inherited a Terraform Repo, Here's How I Reviewed and Hardened It                  | `Aws-3tier-Infrastructure-using-Terraform` | ❌ TODO |
 | 11  | Automating Linux Server Audits with Bash                                             | `server-audit-kit`                         | ❌ TODO |
 | 12  | My Portable DevOps Workstation: Tools That Follow Me Everywhere                      | `portable-lab-setup`                       | ❌ TODO |
 
@@ -66,7 +66,7 @@ tags: ['tag1', 'tag2']
 
 ## Notes
 
-- Hackathon series doubles as submission narrative — judges value documented thinking
+- Hackathon series doubles as submission narrative, judges value documented thinking
 - DevOps posts can reference GitHub repos directly for credibility
 - Quick Hits should be punchy, one-problem-one-lesson format
 - Aim for 1 post per week minimum during hackathon period

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -40,7 +40,7 @@ export const projects: Project[] = [
 - Produces deterministic findings for comparison and replay
 - Adds one constrained AI pass for explanation and triage prioritization
 - Keeps remediation out of scope while trust boundaries are established`,
-    image: '/images/rocketchat-logs-viewer-web-ui.png',
+    image: '/images/signalforge-home-real.png',
     tags: ['Python', 'React', 'TypeScript', 'Observability', 'OpenTelemetry', 'LLM'],
     category: 'DevOps',
     featured: true,

--- a/src/constants/projectDetails.ts
+++ b/src/constants/projectDetails.ts
@@ -277,7 +277,7 @@ Centralized observability hub deployed on **Oracle Kubernetes Engine (OKE)** to 
       'Used Terraform for OCI/OKE lifecycle and ArgoCD for continuous reconciliation of the observability stack',
     ],
     impact:
-      'A centralized, secure observability platform for multi-environment telemetry, demonstrating SRE practices around secure ingestion, storage design, and operational readiness—with Terraform + ArgoCD patterns for repeatable infrastructure and application changes.',
+      'A centralized, secure observability platform for multi-environment telemetry, demonstrating SRE practices around secure ingestion, storage design, and operational readiness, with Terraform + ArgoCD patterns for repeatable infrastructure and application changes.',
     technologies: {
       Kubernetes: ['OKE', 'NGINX Ingress', 'cert-manager', 'Helm'],
       Observability: ['Grafana', 'Prometheus', 'Loki', 'Tempo', 'Alertmanager'],

--- a/src/constants/projectDetails.ts
+++ b/src/constants/projectDetails.ts
@@ -77,6 +77,12 @@ The design is deliberate:
 - produce operator-facing findings with a clear source trail
 - support bounded automation decisions instead of broad model autonomy
 
+## What it looks like
+
+![SignalForge run detail with ranked operator priorities, findings, and analysis metadata](/images/signalforge-run-real.png)
+
+![SignalForge compare view showing deterministic finding drift between two runs](/images/signalforge-compare-real.png)
+
 ## Why this is a flagship line
 
 The project pushes the same trust model used in production systems:

--- a/src/content/experience.ts
+++ b/src/content/experience.ts
@@ -32,7 +32,7 @@ export const experience: ExperienceItem[] = [
   },
   {
     company: 'Tek Experts',
-    role: 'Technical Lead – Cloud Engineering',
+    role: 'Technical Lead, Cloud Engineering',
     location: 'Lagos State, Nigeria',
     start: '2020-01',
     end: '2020-11',


### PR DESCRIPTION
## Summary

Portfolio content corrections, found while reviewing this PR's deploy preview. Two parts.

### 1. Anti-AI dash sweep
Removed every em and en dash (an AI-writing tell) from the rendered site text: the published blog posts, the blog roadmap, and site content/constants. Around 85 dashes, each replaced in context (commas for asides, colons for definition-list lead-ins, periods for one-liners, "to" for date ranges). Content and meaning unchanged.

### 2. Fix SignalForge project image
The SignalForge project card and detail hero used a Rocket.Chat logs-viewer screenshot (`rocketchat-logs-viewer-web-ui.png`), not SignalForge. Now:
- the hero points at the real diagnostics overview (`signalforge-home-real.png`)
- the detail body embeds the run-detail and compare screenshots, so the page showcases actual SignalForge UI instead of an unrelated app

## Validation
- Zero em or en dashes remain in `content/blog` and `src`.
- `bun run typecheck` passes; lint-staged ran Prettier and ESLint on commit.
- The Netlify deploy preview rebuilds with the corrected hero and screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)