### PR TITLE
Polish recruiter UX across home, projects, blog, and case studies

### DIFF
--- a/src/app/blog/BlogIndexClient.tsx
+++ b/src/app/blog/BlogIndexClient.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { PageShell } from '@/components/layout/PageShell';
+import { SectionCard } from '@/components/layout/SectionCard';
+import { SectionLabel } from '@/components/layout/SectionLabel';
+import type { BlogPostMeta } from '@/lib/blog';
+import { cn } from '@/lib/utils';
+
+type TagCount = { tag: string; count: number };
+
+export default function BlogIndexClient({
+  posts,
+  tags,
+}: {
+  posts: BlogPostMeta[];
+  tags: TagCount[];
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const activeTag = searchParams?.get('tag') ?? 'all';
+  const [selectedTag, setSelectedTag] = useState(activeTag);
+
+  useEffect(() => {
+    setSelectedTag(searchParams?.get('tag') ?? 'all');
+  }, [searchParams]);
+
+  const filteredPosts = useMemo(() => {
+    if (selectedTag === 'all') return posts;
+    return posts.filter(p => p.tags?.includes(selectedTag));
+  }, [posts, selectedTag]);
+
+  const setTag = (tag: string) => {
+    setSelectedTag(tag);
+    const params = new URLSearchParams();
+    if (tag !== 'all') params.set('tag', tag);
+    const qs = params.toString();
+    router.replace(qs ? `/blog?${qs}` : '/blog', { scroll: false });
+  };
+
+  return (
+    <PageShell
+      width="narrow"
+      eyebrow="Writing"
+      title="Blog"
+      description="Notes on DevOps, Kubernetes, CI/CD, and frontend work."
+      back={{ href: '/', label: 'Back home' }}
+    >
+      {tags.length > 0 ? (
+        <SectionCard className="mt-8" padding="md" hover={false}>
+          <SectionLabel>Filter by tag</SectionLabel>
+          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+            <button
+              type="button"
+              onClick={() => setTag('all')}
+              aria-pressed={selectedTag === 'all'}
+              className={cn(
+                'text-sm',
+                selectedTag === 'all'
+                  ? 'font-semibold text-[color:var(--color-text-primary)] underline decoration-[color:var(--color-accent)] underline-offset-8'
+                  : 'text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
+              )}
+            >
+              All <span className="text-xs opacity-70">{posts.length}</span>
+            </button>
+            {tags.map(({ tag, count }) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => setTag(tag)}
+                aria-pressed={selectedTag === tag}
+                className={cn(
+                  'text-sm',
+                  selectedTag === tag
+                    ? 'font-semibold text-[color:var(--color-text-primary)] underline decoration-[color:var(--color-accent)] underline-offset-8'
+                    : 'text-[color:var(--color-text-secondary)] hover:text-[color:var(--color-text-primary)]'
+                )}
+              >
+                {tag} <span className="text-xs opacity-70">{count}</span>
+              </button>
+            ))}
+          </div>
+        </SectionCard>
+      ) : null}
+
+      <div className="mt-10 space-y-4">
+        {filteredPosts.length === 0 ? (
+          <SectionCard hover={false}>
+            <p className="text-[color:var(--color-text-secondary)]">
+              No posts match this tag.{' '}
+              <button
+                type="button"
+                onClick={() => setTag('all')}
+                className="underline underline-offset-4 hover:text-[color:var(--color-text-primary)]"
+              >
+                Show all posts
+              </button>
+            </p>
+          </SectionCard>
+        ) : (
+          filteredPosts.map(p => (
+            <SectionCard key={p.slug} padding="md">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <h2 className="text-xl font-semibold tracking-tight">
+                  <Link
+                    href={`/blog/${encodeURIComponent(p.slug)}`}
+                    className="underline-offset-4 hover:underline"
+                  >
+                    {p.title}
+                  </Link>
+                </h2>
+                <time
+                  className="shrink-0 text-xs text-[color:var(--color-text-secondary)]"
+                  dateTime={p.date}
+                >
+                  {p.date}
+                </time>
+              </div>
+              {p.description ? (
+                <p className="mt-2 text-sm leading-6 text-[color:var(--color-text-secondary)]">
+                  {p.description}
+                </p>
+              ) : null}
+              {p.tags && p.tags.length ? (
+                <p className="mt-3 text-xs text-[color:var(--color-text-secondary)]">
+                  {p.tags.join(' · ')}
+                </p>
+              ) : null}
+            </SectionCard>
+          ))
+        )}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import type { Metadata } from 'next';
-import { getAllBlogPostsMeta } from '@/lib/blog';
-import { PageShell } from '@/components/layout/PageShell';
-import { SectionCard } from '@/components/layout/SectionCard';
+import { Suspense } from 'react';
+
+import BlogIndexClient from '@/app/blog/BlogIndexClient';
+import { getAllBlogPostsMeta, getBlogTagsWithCounts } from '@/lib/blog';
 
 export const dynamic = 'force-static';
 
@@ -14,53 +14,11 @@ export const metadata: Metadata = {
 
 export default function BlogIndexPage() {
   const posts = getAllBlogPostsMeta();
+  const tags = getBlogTagsWithCounts();
 
   return (
-    <PageShell
-      width="narrow"
-      eyebrow="Writing"
-      title="Blog"
-      description="Notes on DevOps, Kubernetes, CI/CD, and frontend work."
-      back={{ href: '/', label: 'Back home' }}
-    >
-      <div className="mt-10 space-y-4">
-        {posts.length === 0 ? (
-          <SectionCard hover={false}>
-            <p className="text-[color:var(--color-text-secondary)]">No posts yet.</p>
-          </SectionCard>
-        ) : (
-          posts.map(p => (
-            <SectionCard key={p.slug} padding="md">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <h2 className="text-xl font-semibold tracking-tight">
-                  <Link
-                    href={`/blog/${encodeURIComponent(p.slug)}`}
-                    className="underline-offset-4 hover:underline"
-                  >
-                    {p.title}
-                  </Link>
-                </h2>
-                <time
-                  className="shrink-0 text-xs text-[color:var(--color-text-secondary)]"
-                  dateTime={p.date}
-                >
-                  {p.date}
-                </time>
-              </div>
-              {p.description ? (
-                <p className="mt-2 text-sm leading-6 text-[color:var(--color-text-secondary)]">
-                  {p.description}
-                </p>
-              ) : null}
-              {p.tags && p.tags.length ? (
-                <p className="mt-3 text-xs text-[color:var(--color-text-secondary)]">
-                  {p.tags.join(' · ')}
-                </p>
-              ) : null}
-            </SectionCard>
-          ))
-        )}
-      </div>
-    </PageShell>
+    <Suspense fallback={null}>
+      <BlogIndexClient posts={posts} tags={tags} />
+    </Suspense>
   );
 }

--- a/src/app/contact/ContactClient.tsx
+++ b/src/app/contact/ContactClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { type ChangeEvent, type FormEvent, useState } from 'react';
+import React, { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from 'react';
 
 import { PageShell } from '@/components/layout/PageShell';
 import { SectionCard } from '@/components/layout/SectionCard';
@@ -19,6 +19,13 @@ interface ContactForm {
 export default function ContactClient() {
   const [status, setStatus] = useState<FormStatus>('idle');
   const [form, setForm] = useState<ContactForm>({ name: '', email: '', message: '' });
+  const statusRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    if (status === 'error' || status === 'success') {
+      statusRef.current?.focus();
+    }
+  }, [status]);
 
   const onChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -50,7 +57,7 @@ export default function ContactClient() {
       description="Send a message below. A repo link, job description, or error log helps."
     >
       <SectionCard className="mt-10" padding="lg">
-        <form onSubmit={onSubmit} className="grid gap-5">
+        <form onSubmit={onSubmit} className="grid gap-5" aria-describedby="contact-form-status">
           <div>
             <label htmlFor="contact-name" className="text-sm font-medium">
               Name
@@ -107,16 +114,28 @@ export default function ContactClient() {
             </Button>
           </div>
 
-          {status === 'success' ? (
-            <p role="status" className="text-sm text-[color:var(--color-accent)]">
-              Message sent successfully.
-            </p>
-          ) : null}
-          {status === 'error' ? (
-            <p role="status" className="text-sm text-red-500">
-              Something went wrong. Please try again.
-            </p>
-          ) : null}
+          <div id="contact-form-status" aria-live="polite" aria-atomic="true">
+            {status === 'success' ? (
+              <p
+                ref={statusRef}
+                tabIndex={-1}
+                role="status"
+                className="text-sm text-[color:var(--color-accent)] outline-none"
+              >
+                Message sent successfully.
+              </p>
+            ) : null}
+            {status === 'error' ? (
+              <p
+                ref={statusRef}
+                tabIndex={-1}
+                role="alert"
+                className="text-sm text-red-500 outline-none"
+              >
+                Something went wrong. Please try again.
+              </p>
+            ) : null}
+          </div>
         </form>
       </SectionCard>
     </PageShell>

--- a/src/app/home/HeroVisual.tsx
+++ b/src/app/home/HeroVisual.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { ArrowRight, BarChart3, Boxes, GitBranch, Server, Waypoints } from 'lucide-react';
 
 function Node({
@@ -76,7 +77,7 @@ export default function HeroVisual() {
                 />
                 <div className="flex shrink-0 flex-col items-center justify-center text-[color:var(--color-text-secondary)]">
                   <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                  <div className="mt-1 text-[10px] font-mono">OTLP</div>
+                  <div className="mt-1 font-mono text-[10px]">OTLP</div>
                 </div>
                 <Node
                   label="OKE hub"
@@ -116,8 +117,13 @@ export default function HeroVisual() {
 
       <div className="absolute inset-x-0 bottom-0 border-t border-[color:var(--color-border)] bg-[color:var(--color-bg-primary)] px-4 py-3">
         <p className="text-xs text-[color:var(--color-text-secondary)]">
-          Netlify deploys production. Jenkins runs CI. Details on{' '}
-          <span className="text-[color:var(--color-text-primary)]">/systems</span>.
+          Netlify deploys production. Jenkins runs CI.{' '}
+          <Link
+            href="/systems"
+            className="font-medium text-[color:var(--color-text-primary)] underline underline-offset-4"
+          >
+            Full systems map
+          </Link>
         </p>
       </div>
     </div>

--- a/src/app/home/HomeJumpNav.tsx
+++ b/src/app/home/HomeJumpNav.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { cn } from '@/lib/utils';
+
+const jumps = [
+  { href: '#projects', label: 'Projects' },
+  { href: '#experience', label: 'Experience' },
+  { href: '#skills', label: 'Skills' },
+  { href: '#writing', label: 'Writing' },
+  { href: '#contact', label: 'Contact' },
+] as const;
+
+export default function HomeJumpNav() {
+  const pathname = usePathname();
+
+  if (pathname !== '/') return null;
+
+  return (
+    <nav
+      aria-label="On this page"
+      className="mt-8 flex flex-wrap gap-x-4 gap-y-2 border-y border-[color:var(--color-border)] py-4 text-sm"
+    >
+      {jumps.map(item => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className={cn(
+            'text-[color:var(--color-text-secondary)] underline-offset-4 hover:text-[color:var(--color-text-primary)] hover:underline'
+          )}
+        >
+          {item.label}
+        </Link>
+      ))}
+      <Link
+        href="/systems"
+        className="text-[color:var(--color-text-secondary)] underline-offset-4 hover:text-[color:var(--color-text-primary)] hover:underline"
+      >
+        Systems
+      </Link>
+    </nav>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google';
 
 import AppShell from '@/app/shared/AppShell';
 import { profile } from '@/content/profile';
+import { getSiteUrl } from '@/lib/site';
 
 import '@/styles/GlobalStyles.css';
 import '@/styles/globals.css';
@@ -23,11 +24,33 @@ const ibmPlexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getSiteUrl()),
   title: {
     default: profile.name,
     template: `%s | ${profile.name}`,
   },
   description: 'Vincent Mogah: platform engineering, CI/CD tooling, and Kubernetes operations.',
+  openGraph: {
+    type: 'website',
+    locale: 'en_GB',
+    siteName: profile.name,
+    title: profile.name,
+    description: 'Platform reliability work: case studies, systems map, and technical writing.',
+    images: [
+      {
+        url: '/images/new-portfolio-site.png',
+        width: 1280,
+        height: 800,
+        alt: 'Portfolio homepage',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: profile.name,
+    description: 'Platform reliability work: case studies, systems map, and technical writing.',
+    images: ['/images/new-portfolio-site.png'],
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -44,7 +67,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Script id="theme-init" src="/theme-init.js?v=2" strategy="beforeInteractive" />
 
         <link rel="icon" href="/favicon.ico" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/favicon.ico" />
+        <link rel="apple-touch-icon" href="/images/profile.jpeg" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon.ico" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon.ico" />
         <meta name="color-scheme" content="dark light" />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -18,7 +18,13 @@ export default function NotFound() {
           <Link href="/projects">Projects</Link>
         </Button>
         <Button variant="glass" asChild>
+          <Link href="/systems">Systems</Link>
+        </Button>
+        <Button variant="glass" asChild>
           <Link href="/blog">Blog</Link>
+        </Button>
+        <Button variant="glass" asChild>
+          <Link href="/contact">Contact</Link>
         </Button>
       </div>
     </PageShell>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
+import { Mail } from 'lucide-react';
 
 import HeroVisual from '@/app/home/HeroVisual';
+import HomeJumpNav from '@/app/home/HomeJumpNav';
 import { PageSection } from '@/components/layout/PageShell';
 import { SectionHeader, SectionHeaderMobileAction } from '@/components/layout/SectionHeader';
 import { SectionCard } from '@/components/layout/SectionCard';
@@ -19,7 +21,7 @@ export const dynamic = 'force-static';
 export default function HomePage() {
   const posts = getAllBlogPostsMeta().slice(0, 2);
   const featured = projects.filter(p => p.featured).slice(0, 3);
-  const featuredCerts = certifications.slice(0, 4);
+  const featuredCerts = certifications.slice(0, 2);
   const currentRole = experience[0];
   const githubHref = safeExternalHref(profile.links.github);
   const linkedinHref = safeExternalHref(profile.links.linkedin);
@@ -35,8 +37,8 @@ export default function HomePage() {
   ];
 
   return (
-    <div className="px-6 py-10 md:px-10">
-      <PageSection spacing="none">
+    <div className="mx-auto max-w-6xl px-6 py-10 md:px-10">
+      <PageSection spacing="none" className="max-w-none px-0">
         <div className="grid gap-10 md:grid-cols-2 md:items-stretch">
           <div className="border-l-2 border-[color:var(--color-accent)] pl-6">
             <SectionLabel>Reliability engineer · UK</SectionLabel>
@@ -60,9 +62,10 @@ export default function HomePage() {
 
           <HeroVisual />
         </div>
+        <HomeJumpNav />
       </PageSection>
 
-      <PageSection id="about" spacing="default" className="mt-14">
+      <PageSection id="about" spacing="default" className="mt-14 max-w-none px-0">
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)]">
           <SectionCard padding="lg">
             <SectionLabel>Profile</SectionLabel>
@@ -131,7 +134,7 @@ export default function HomePage() {
             <SectionCard>
               <SectionLabel>Certifications</SectionLabel>
               <div className="mt-3 space-y-2">
-                {featuredCertsSafe.slice(0, 3).map(c => (
+                {featuredCertsSafe.map(c => (
                   <a
                     key={c.name}
                     href={c.href}
@@ -146,12 +149,17 @@ export default function HomePage() {
                   </a>
                 ))}
               </div>
+              {certifications.length > featuredCertsSafe.length ? (
+                <p className="mt-3 text-xs text-[color:var(--color-text-secondary)]">
+                  +{certifications.length - featuredCertsSafe.length} more on LinkedIn.
+                </p>
+              ) : null}
             </SectionCard>
           </div>
         </div>
       </PageSection>
 
-      <PageSection id="projects">
+      <PageSection id="projects" className="max-w-none px-0">
         <SectionHeader
           title="Selected work"
           description="PipelineHealer and SignalForge first. Other entries are platform depth."
@@ -167,7 +175,7 @@ export default function HomePage() {
         <SectionHeaderMobileAction href="/projects" label="View all projects" />
       </PageSection>
 
-      <PageSection id="experience">
+      <PageSection id="experience" className="max-w-none px-0">
         <SectionHeader
           title="Experience"
           description="Enterprise support and platform roles across cloud, CI/CD, and incident response."
@@ -179,7 +187,7 @@ export default function HomePage() {
         />
 
         <div className="mt-10 grid gap-4 md:grid-cols-2">
-          {experience.slice(0, 4).map(item => (
+          {experience.slice(0, 2).map(item => (
             <SectionCard key={`${item.company}-${item.role}-${item.start}`}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
@@ -199,7 +207,7 @@ export default function HomePage() {
                 </div>
               ) : null}
               <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-[color:var(--color-text-secondary)]">
-                {item.highlights.map(h => (
+                {item.highlights.slice(0, 2).map(h => (
                   <li key={h}>{h}</li>
                 ))}
               </ul>
@@ -216,7 +224,7 @@ export default function HomePage() {
         ) : null}
       </PageSection>
 
-      <PageSection id="skills">
+      <PageSection id="skills" className="max-w-none px-0">
         <SectionHeader
           title="Skills"
           description="Grouped by area, with links to the project pages where each shows up."
@@ -286,7 +294,7 @@ export default function HomePage() {
         </div>
       </PageSection>
 
-      <PageSection id="writing">
+      <PageSection id="writing" className="max-w-none px-0">
         <SectionHeader
           title="Writing"
           description="Notes from migrations, CI changes, and production failures."
@@ -330,6 +338,36 @@ export default function HomePage() {
         </div>
 
         <SectionHeaderMobileAction href="/blog" label="View all posts" />
+      </PageSection>
+
+      <PageSection id="contact" className="max-w-none px-0">
+        <SectionCard padding="lg">
+          <SectionLabel>Contact</SectionLabel>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl">
+            Hiring or have a platform problem?
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-7 text-[color:var(--color-text-secondary)] md:text-base">
+            Email works best. Include a repo link, job description, or error log if you have one.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Button variant="accent" size="lg" className="h-11 gap-2" asChild>
+              <Link href="/contact">Send a message</Link>
+            </Button>
+            <Button variant="glass" size="lg" className="h-11 gap-2" asChild>
+              <a href={`mailto:${profile.email}`}>
+                <Mail className="h-4 w-4" aria-hidden="true" />
+                Email
+              </a>
+            </Button>
+            {linkedinHref ? (
+              <Button variant="glass" size="lg" className="h-11" asChild>
+                <a href={linkedinHref} target="_blank" rel="noopener noreferrer">
+                  LinkedIn
+                </a>
+              </Button>
+            ) : null}
+          </div>
+        </SectionCard>
       </PageSection>
     </div>
   );

--- a/src/app/projects/ProjectsPageClient.tsx
+++ b/src/app/projects/ProjectsPageClient.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { PageShell } from '@/components/layout/PageShell';
 import { SectionCard } from '@/components/layout/SectionCard';
@@ -21,13 +21,40 @@ function hasLiveDemo(project: Project): boolean {
   return true;
 }
 
+function readCategoryParam(value: string | null): string {
+  if (!value) return 'all';
+  return projectCategories.some(c => c.value === value) ? value : 'all';
+}
+
 export default function ProjectsPageClient() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const mode = searchParams?.get('mode');
   const liveOnly = mode === 'live';
 
-  const [searchTerm, setSearchTerm] = useState<string>('');
-  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [searchTerm, setSearchTerm] = useState(() => searchParams?.get('q') ?? '');
+  const [selectedCategory, setSelectedCategory] = useState(() =>
+    readCategoryParam(searchParams?.get('category') ?? null)
+  );
+
+  useEffect(() => {
+    setSearchTerm(searchParams?.get('q') ?? '');
+    setSelectedCategory(readCategoryParam(searchParams?.get('category') ?? null));
+  }, [searchParams]);
+
+  const syncUrl = (next: { q?: string; category?: string; live?: boolean }) => {
+    const params = new URLSearchParams();
+    const q = next.q ?? searchTerm;
+    const category = next.category ?? selectedCategory;
+    const live = next.live ?? liveOnly;
+
+    if (live) params.set('mode', 'live');
+    if (category !== 'all') params.set('category', category);
+    if (q.trim()) params.set('q', q.trim());
+
+    const qs = params.toString();
+    router.replace(qs ? `/projects?${qs}` : '/projects', { scroll: false });
+  };
 
   const filteredProjects = useMemo((): Project[] => {
     return projects.filter(project => {
@@ -97,7 +124,11 @@ export default function ProjectsPageClient() {
               type="text"
               placeholder="Search by project, stack, or problem space"
               value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
+              onChange={e => {
+                const q = e.target.value;
+                setSearchTerm(q);
+                syncUrl({ q });
+              }}
               aria-label="Search projects"
               className="mt-3 h-11"
             />
@@ -120,7 +151,10 @@ export default function ProjectsPageClient() {
                   <button
                     key={category.value}
                     type="button"
-                    onClick={() => setSelectedCategory(category.value)}
+                    onClick={() => {
+                      setSelectedCategory(category.value);
+                      syncUrl({ category: category.value });
+                    }}
                     aria-pressed={isActive}
                     className={
                       isActive
@@ -154,6 +188,7 @@ export default function ProjectsPageClient() {
               onClick={() => {
                 setSearchTerm('');
                 setSelectedCategory('all');
+                syncUrl({ q: '', category: 'all' });
               }}
             >
               Clear filters

--- a/src/app/projects/[slug]/ProjectDetailClient.tsx
+++ b/src/app/projects/[slug]/ProjectDetailClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -11,13 +11,17 @@ import { SectionCard } from '@/components/layout/SectionCard';
 import { SectionLabel } from '@/components/layout/SectionLabel';
 import { Button } from '@/components/ui/button';
 import { projectDetails } from '@/constants/projectDetails';
+import { projectMediaFit } from '@/lib/project-media';
 import { proseClasses } from '@/lib/prose';
 import { safeExternalHref } from '@/lib/url';
 import { cn } from '@/lib/utils';
 import type { Project } from '@/types/project';
 
 export default function ProjectDetailClient({ project, slug }: { project: Project; slug: string }) {
-  const details = projectDetails[slug] || {};
+  const fullProject = useMemo(
+    () => ({ ...project, ...(projectDetails[slug] || {}) }),
+    [project, slug]
+  );
 
   useEffect(() => {
     import('@/lib/analytics')
@@ -27,17 +31,23 @@ export default function ProjectDetailClient({ project, slug }: { project: Projec
       .catch(() => {});
   }, [project.slug, project.title]);
 
-  const fullProject = { ...project, ...details };
   const heroSrc = (fullProject as Project).media || project.media || project.image;
-  const heroFit =
-    heroSrc.toLowerCase().endsWith('.gif') ||
-    heroSrc.toLowerCase().endsWith('.mp4') ||
-    heroSrc.toLowerCase().endsWith('.webm')
-      ? 'contain'
-      : 'cover';
+  const heroFit = projectMediaFit(heroSrc);
   const visitHref = safeExternalHref(project.visit);
   const sourceHref = safeExternalHref(project.source);
   const meta = [project.category, project.featured ? 'Featured' : null].filter(Boolean).join(' · ');
+
+  const tocSections = useMemo(() => {
+    const items: { id: string; label: string }[] = [{ id: 'overview', label: 'Overview' }];
+    if (fullProject.impact) items.push({ id: 'impact', label: 'Impact' });
+    if (fullProject.challenges && fullProject.solutions) {
+      items.push({ id: 'challenges-and-solutions', label: 'Challenges and solutions' });
+    }
+    if (fullProject.technologies) items.push({ id: 'technology-stack', label: 'Technology stack' });
+    return items;
+  }, [fullProject]);
+
+  const showToc = tocSections.length > 1;
 
   return (
     <PageShell
@@ -58,7 +68,7 @@ export default function ProjectDetailClient({ project, slug }: { project: Projec
           priority
           poster={project.image}
           fit={heroFit}
-          className="h-full w-full"
+          className={heroFit === 'contain' ? 'object-contain p-3' : 'object-cover'}
         />
       </div>
 
@@ -68,8 +78,25 @@ export default function ProjectDetailClient({ project, slug }: { project: Projec
         </p>
       ) : null}
 
+      {showToc ? (
+        <nav
+          aria-label="On this page"
+          className="mt-8 flex flex-wrap gap-x-4 gap-y-2 border-y border-[color:var(--color-border)] py-4 text-sm"
+        >
+          {tocSections.map(item => (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              className="text-[color:var(--color-text-secondary)] underline-offset-4 hover:text-[color:var(--color-text-primary)] hover:underline"
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+      ) : null}
+
       <div className="mt-12 space-y-12">
-        <ContentSection title="Overview">
+        <ContentSection title="Overview" id="overview">
           <div className={cn('max-w-3xl', proseClasses)}>
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {fullProject.longDescription || project.description}
@@ -78,16 +105,18 @@ export default function ProjectDetailClient({ project, slug }: { project: Projec
         </ContentSection>
 
         {fullProject.impact ? (
-          <SectionCard padding="lg">
-            <SectionLabel>Impact</SectionLabel>
-            <p className="mt-3 text-sm leading-7 text-[color:var(--color-text-secondary)] md:text-base">
-              {fullProject.impact}
-            </p>
-          </SectionCard>
+          <section id="impact" className="scroll-mt-24">
+            <SectionCard padding="lg">
+              <SectionLabel>Impact</SectionLabel>
+              <p className="mt-3 text-sm leading-7 text-[color:var(--color-text-secondary)] md:text-base">
+                {fullProject.impact}
+              </p>
+            </SectionCard>
+          </section>
         ) : null}
 
         {fullProject.challenges && fullProject.solutions ? (
-          <ContentSection title="Challenges and solutions">
+          <ContentSection title="Challenges and solutions" id="challenges-and-solutions">
             <div className="grid gap-4 md:grid-cols-2">
               <SectionCard hover={false}>
                 <h3 className="text-lg font-semibold tracking-tight">Challenges</h3>
@@ -110,7 +139,7 @@ export default function ProjectDetailClient({ project, slug }: { project: Projec
         ) : null}
 
         {fullProject.technologies ? (
-          <ContentSection title="Technology stack">
+          <ContentSection title="Technology stack" id="technology-stack">
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {Object.entries(fullProject.technologies).map(([category, techs]) => (
                 <SectionCard key={category} hover={false}>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 
 import ProjectsPageClient from '@/app/projects/ProjectsPageClient';
 
@@ -11,5 +12,9 @@ export const metadata: Metadata = {
 };
 
 export default function ProjectsPage() {
-  return <ProjectsPageClient />;
+  return (
+    <Suspense fallback={null}>
+      <ProjectsPageClient />
+    </Suspense>
+  );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,20 +2,7 @@ import type { MetadataRoute } from 'next';
 
 import { projects } from '@/constants/constants';
 import { getBlogSlugs } from '@/lib/blog';
-
-// Next.js route config expects a literal here (not an expression).
-export const revalidate = 3600; // 1 hour
-
-function getSiteUrl(): string {
-  const fallback = 'https://portfolio.canepro.me';
-  const raw = process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || fallback;
-  try {
-    const url = new URL(raw);
-    return url.toString().replace(/\/$/, '');
-  } catch {
-    return fallback;
-  }
-}
+import { getSiteUrl } from '@/lib/site';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const siteUrl = getSiteUrl();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -65,6 +65,14 @@ export default function Header() {
   }, [pathname]);
 
   useEffect(() => {
+    if (open) {
+      document.body.classList.add('mobile-nav-open');
+      return () => document.body.classList.remove('mobile-nav-open');
+    }
+    document.body.classList.remove('mobile-nav-open');
+  }, [open]);
+
+  useEffect(() => {
     if (!open || !menuRef.current) return;
 
     const panel = menuRef.current;

--- a/src/components/ProjectMedia/ProjectMedia.tsx
+++ b/src/components/ProjectMedia/ProjectMedia.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
 import OptimizedImage from '../OptimizedImage/OptimizedImage';
 
 type MediaFit = 'cover' | 'contain';
@@ -32,8 +34,17 @@ const ProjectMedia: React.FC<ProjectMediaProps> = ({
   fit = 'cover',
   poster,
 }) => {
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduceMotion(media.matches);
+    sync();
+    media.addEventListener('change', sync);
+    return () => media.removeEventListener('change', sync);
+  }, []);
+
   if (isVideoSrc(src)) {
-    // For "fill" layout we need a positioned wrapper that matches next/image behavior.
     const wrapperClassName = fill ? 'absolute inset-0' : undefined;
     const objectFitClass = fit === 'contain' ? 'object-contain' : 'object-cover';
     const preload = priority ? 'auto' : 'metadata';
@@ -43,9 +54,9 @@ const ProjectMedia: React.FC<ProjectMediaProps> = ({
         <video
           aria-label={alt}
           className={['h-full w-full', objectFitClass, className].filter(Boolean).join(' ')}
-          autoPlay
+          autoPlay={!reduceMotion}
           muted
-          loop
+          loop={!reduceMotion}
           playsInline
           preload={preload}
           poster={poster}

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -4,11 +4,13 @@ import { ProjectCardProps } from '../../types/components';
 import { Button } from '../ui/button';
 import { Github, ExternalLink, BarChart3 } from 'lucide-react';
 import ProjectMedia from '../ProjectMedia/ProjectMedia';
+import { projectMediaFit } from '@/lib/project-media';
 import { safeExternalHref } from '@/lib/url';
 
 const ProjectCard: React.FC<ProjectCardProps> = ({ project, index = 0 }) => {
   const isGrafanaProject = project.slug === 'central-observability-hub-stack';
   const previewSrc = project.media || project.image;
+  const mediaFit = projectMediaFit(previewSrc);
   const projectHref = `/projects/${encodeURIComponent(project.slug)}`;
   const visitHref = safeExternalHref(project.visit);
   const sourceHref = safeExternalHref(project.source);
@@ -26,7 +28,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index = 0 }) => {
 
   return (
     <article className="relative flex flex-col overflow-hidden rounded-2xl border border-[color:var(--color-border)] bg-[color:var(--color-card-bg)] text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-card-hover)]">
-      <Link href={projectHref} className="relative block aspect-video overflow-hidden">
+      <Link
+        href={projectHref}
+        className="relative block aspect-video overflow-hidden bg-[color:var(--color-bg-primary)]"
+      >
         <ProjectMedia
           src={previewSrc}
           alt={`${project.title} thumbnail`}
@@ -34,8 +39,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index = 0 }) => {
           sizes="(max-width: 640px) 100vw, (max-width: 1200px) 50vw, 400px"
           priority={index < 4}
           poster={project.image}
-          fit="cover"
-          className="object-cover"
+          fit={mediaFit}
+          className={mediaFit === 'contain' ? 'object-contain p-2' : 'object-cover'}
         />
       </Link>
 

--- a/src/components/Projects/ProjectPreviewCard.tsx
+++ b/src/components/Projects/ProjectPreviewCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 
 import ProjectMedia from '@/components/ProjectMedia/ProjectMedia';
+import { projectMediaFit } from '@/lib/project-media';
 import { Button } from '@/components/ui/button';
 import { safeExternalHref } from '@/lib/url';
 import type { Project } from '@/types/project';
@@ -20,6 +21,7 @@ export default function ProjectPreviewCard({
   className,
 }: ProjectPreviewCardProps) {
   const previewSrc = project.media || project.image;
+  const mediaFit = projectMediaFit(previewSrc);
   const projectHref = `/projects/${encodeURIComponent(project.slug)}`;
   const visitHref = safeExternalHref(project.visit);
   const meta = [project.category, project.featured ? 'Featured' : null].filter(Boolean).join(' · ');
@@ -31,7 +33,10 @@ export default function ProjectPreviewCard({
         className
       )}
     >
-      <Link href={projectHref} className="relative block aspect-video overflow-hidden">
+      <Link
+        href={projectHref}
+        className="relative block aspect-video overflow-hidden bg-[color:var(--color-bg-primary)]"
+      >
         <ProjectMedia
           src={previewSrc}
           alt={`${project.title} preview`}
@@ -39,8 +44,8 @@ export default function ProjectPreviewCard({
           sizes="(max-width: 640px) 100vw, (max-width: 1200px) 50vw, 400px"
           priority={priority}
           poster={project.image}
-          fit="cover"
-          className="object-cover"
+          fit={mediaFit}
+          className={mediaFit === 'contain' ? 'object-contain p-2' : 'object-cover'}
         />
       </Link>
 

--- a/src/components/layout/ContentSection.tsx
+++ b/src/components/layout/ContentSection.tsx
@@ -2,19 +2,30 @@ import { cn } from '@/lib/utils';
 
 type ContentSectionProps = {
   title: string;
+  id?: string;
   children: React.ReactNode;
   className?: string;
   headingClassName?: string;
 };
 
+function slugifyHeading(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
 export function ContentSection({
   title,
+  id,
   children,
   className,
   headingClassName,
 }: ContentSectionProps) {
+  const sectionId = id ?? slugifyHeading(title);
+
   return (
-    <section className={className}>
+    <section id={sectionId} className={cn('scroll-mt-24', className)}>
       <h2 className={cn('text-2xl font-semibold tracking-tight', headingClassName)}>{title}</h2>
       <div className="mt-5">{children}</div>
     </section>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -88,6 +88,18 @@ export function getAllBlogPostsMeta(): BlogPostMeta[] {
   return posts;
 }
 
+export function getBlogTagsWithCounts(): { tag: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const post of getAllBlogPostsMeta()) {
+    for (const tag of post.tags ?? []) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
 export function getBlogPostSource(slug: string): { meta: BlogPostMeta; source: string } {
   if (!SLUG_RE.test(slug)) {
     throw new Error(`Invalid blog slug: ${slug}`);

--- a/src/lib/project-media.ts
+++ b/src/lib/project-media.ts
@@ -1,0 +1,11 @@
+export type MediaFit = 'cover' | 'contain';
+
+const ANIMATED_EXT = /\.(gif|mp4|webm)$/i;
+
+export function isAnimatedMediaSrc(src: string): boolean {
+  return ANIMATED_EXT.test(src);
+}
+
+export function projectMediaFit(src: string): MediaFit {
+  return isAnimatedMediaSrc(src) ? 'contain' : 'cover';
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,10 @@
+export function getSiteUrl(): string {
+  const fallback = 'https://portfolio.canepro.me';
+  const raw = process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL || fallback;
+  try {
+    const url = new URL(raw);
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return fallback;
+  }
+}

--- a/src/styles/GlobalStyles.css
+++ b/src/styles/GlobalStyles.css
@@ -197,3 +197,9 @@ html.light-theme .image-shimmer {
   );
   background-size: 200% 100%;
 }
+
+@media (max-width: 767px) {
+  body.mobile-nav-open iframe[src*='livechat'] {
+    visibility: hidden !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Home: jump nav, trimmed experience/certs, closing contact CTA, aligned max-width layout
- SEO/sharing: Open Graph and Twitter metadata with homepage screenshot
- Projects: shareable URL filters (`?category=`, `?q=`); blog tag filter (`?tag=`)
- Case studies: in-page TOC, consistent GIF/video media fit via shared helper
- A11y/mobile: contact form `aria-live`, 404 nav links, live-chat hidden when mobile drawer is open

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] Verify home jump links scroll to sections on mobile and desktop
- [ ] Verify `/projects?category=observability` and `/blog?tag=kubernetes` filter correctly
- [ ] Check LinkedIn/Slack preview after deploy (OG image)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based filtering to blog index page with dynamic post counts
  * Added "On this page" navigation to home and project detail pages
  * Added reduced-motion support for video autoplay and looping
  * Enhanced project filtering with URL persistence for search and category

* **Bug Fixes**
  * Improved contact form status messaging accessibility
  * Fixed LiveChat visibility on mobile with open navigation menu

* **Style**
  * Updated home page to display 2 featured certifications and 2 experience items
  * Enhanced hero section with clickable systems link
  * Expanded 404 page navigation options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Canepro/portfolio_website-main/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->